### PR TITLE
フッターメニューのカレント表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'sidekiq'
 # SEO
 gem 'meta-tags'
 
+# フッターメニューにactive_navタグを付与
+gem 'active_link_to'
+
 group :development, :test do
   gem 'annotate'
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (7.0.4)
       activesupport (= 7.0.4)
       globalid (>= 0.3.6)
@@ -386,6 +389,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_link_to
   activestorage-validator
   annotate
   bootsnap

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,17 +1,17 @@
-<div id="footer-bar" class="footer-bar-6">
-  <%= link_to root_path, class: 'active-nav footer-menu' do %>
+<div id="footer-bar" class="footer-bar-1">
+  <%= active_link_to root_path, class: 'footer-menu', active: :exclusive, class_active: 'active-nav' do %>
     <i class="fas fa-home"></i><span>トップ</span>
   <% end %>
-  <%= link_to root_path, class: 'footer-menu' do %>
+  <%= active_link_to about_path, class: 'footer-menu', active: :exclusive, class_active: 'active-nav' do %>
       <i class="fas fa-lightbulb"></i><span>手放す</span>
   <% end %>
-  <%= link_to root_path, class: 'footer-menu' do %>
+  <%= active_link_to privacy_path, class: 'footer-menu', active: :exclusive, class_active: 'active-nav' do %>
     <i class="fas fa-dove"></i><span>手放した</span>
   <% end %>
-  <%= link_to root_path, class: 'footer-menu' do %>
+  <%= active_link_to term_path, class: 'footer-menu', active: :exclusive, class_active: 'active-nav' do %>
     <i class="fas fa-quote-right"></i><span>名言集</span>
   <% end %>
-  <%= link_to root_path, class: 'footer-menu' do %>
+  <%= active_link_to login_path, class: 'footer-menu', active: :exclusive, class_active: 'active-nav' do %>
     <i class="fas fa-trophy"></i><span>実績</span>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,10 @@
 #                                   signup GET    /signup(.:format)                                                                                 users/registrations#new
 #                                    login GET    /login(.:format)                                                                                  users/sessions#new
 #                                   logout GET    /logout(.:format)                                                                                 users/sessions#destroy
-#                                     root GET    /                                                                                                 samples#index
+#                                     root GET    /                                                                                                 static_pages#top
+#                                    about GET    /about(.:format)                                                                                  static_pages#about
+#                                  privacy GET    /privacy(.:format)                                                                                static_pages#privacy
+#                                     term GET    /term(.:format)                                                                                   static_pages#term
 #                              sidekiq_web        /sidekiq                                                                                          Sidekiq::Web
 
 Rails.application.routes.draw do


### PR DESCRIPTION
概要
---

issue: #40 

フッターメニューのリンクを、カレント表示（＝現在ページのリンクを目立たせる）ができるよう改善しました。

UI の変更
----

![issue-40_foter_menu_active_state](https://user-images.githubusercontent.com/105996822/210039701-39f2d294-77cc-43f2-93b5-dde0171ffc29.png)


追加した Gem
---

- [active_link_to](https://github.com/comfy/active_link_to)

備考
---

- 現状カレント表示の方法の一つとして、アイコンと添字の色を変えるようにしているが、明度差的にちょっと見にくいかも？現在ページのリンクに下線をひく目立たせ方のほうが見やすいかも。
- フッターメニューのリンクは、active-navクラスの切り替えがうまくいくかを見るために各リンクで違うパスを指定した方が良いのではと考え、暫定的に静的ページのパスを指定している。
- 所要時間：1.6h　（gemを使う前にjQueryでなんとかならないか試した。turboとの兼ね合いか正常に表示ができなかった）