### PR TITLE
「手放したいものリスト」のモデル生成

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,5 +17,5 @@ class Category < ApplicationRecord
   validates :description, presence: true
   validates :name, uniqueness: true
 
-  has_many :to_let_go_lists
+  has_many :to_let_go_lists, dependent: :destroy
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,4 +16,6 @@ class Category < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :name, uniqueness: true
+
+  has_many :to_let_go_lists
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -17,5 +17,5 @@ class Reason < ApplicationRecord
   validates :description, presence: true
   validates :name, uniqueness: true
 
-  has_many :to_let_go_lists
+  has_many :to_let_go_lists, dependent: :destroy
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -16,4 +16,6 @@ class Reason < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :name, uniqueness: true
+
+  has_many :to_let_go_lists
 end

--- a/app/models/to_let_go_list.rb
+++ b/app/models/to_let_go_list.rb
@@ -26,4 +26,5 @@ class ToLetGoList < ApplicationRecord
   belongs_to :category
   belongs_to :reason
   belongs_to :user
+  has_one_attached :image
 end

--- a/app/models/to_let_go_list.rb
+++ b/app/models/to_let_go_list.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: to_let_go_lists
+#
+#  id          :bigint           not null, primary key
+#  item        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  reason_id   :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_to_let_go_lists_on_category_id  (category_id)
+#  index_to_let_go_lists_on_reason_id    (reason_id)
+#  index_to_let_go_lists_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (reason_id => reasons.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class ToLetGoList < ApplicationRecord
+  belongs_to :category
+  belongs_to :reason
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,5 +25,5 @@ class User < ApplicationRecord
 
   validates :username, presence: true
 
-  has_many :to_let_go_lists
+  has_many :to_let_go_lists, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :username, presence: true
+
+  has_many :to_let_go_lists
 end

--- a/db/migrate/20221230111338_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20221230111338_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20221230112622_create_to_let_go_lists.rb
+++ b/db/migrate/20221230112622_create_to_let_go_lists.rb
@@ -1,0 +1,12 @@
+class CreateToLetGoLists < ActiveRecord::Migration[7.0]
+  def change
+    create_table :to_let_go_lists do |t|
+      t.references :category, null: false, foreign_key: true
+      t.string :item
+      t.references :reason, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_30_111338) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_30_112622) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -55,6 +55,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_30_111338) do
     t.index ["name"], name: "index_reasons_on_name", unique: true
   end
 
+  create_table "to_let_go_lists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "item"
+    t.bigint "reason_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_to_let_go_lists_on_category_id"
+    t.index ["reason_id"], name: "index_to_let_go_lists_on_reason_id"
+    t.index ["user_id"], name: "index_to_let_go_lists_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "username", null: false
     t.string "email", default: "", null: false
@@ -70,4 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_30_111338) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "to_let_go_lists", "categories"
+  add_foreign_key "to_let_go_lists", "reasons"
+  add_foreign_key "to_let_go_lists", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_30_092130) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_30_111338) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
@@ -40,4 +68,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_30_092130) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/factories/to_let_go_lists.rb
+++ b/spec/factories/to_let_go_lists.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: to_let_go_lists
+#
+#  id          :bigint           not null, primary key
+#  item        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  reason_id   :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_to_let_go_lists_on_category_id  (category_id)
+#  index_to_let_go_lists_on_reason_id    (reason_id)
+#  index_to_let_go_lists_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (reason_id => reasons.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :to_let_go_list do
+    category
+    item { [Faker::Lorem.word, nil].sample }
+    reason
+    user
+  end
+end

--- a/spec/models/to_let_go_list_spec.rb
+++ b/spec/models/to_let_go_list_spec.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: to_let_go_lists
+#
+#  id          :bigint           not null, primary key
+#  item        :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  reason_id   :bigint           not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_to_let_go_lists_on_category_id  (category_id)
+#  index_to_let_go_lists_on_reason_id    (reason_id)
+#  index_to_let_go_lists_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (reason_id => reasons.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe ToLetGoList, type: :model do
+  subject { build(:to_let_go_list) }
+  it { is_expected.to be_valid }
+end


### PR DESCRIPTION
概要
---

issue: #19 

手放したいものリストのモデルを作成しました。


実装の詳細
----

| テーブル名 | カラム名 | 内容 |
| :---: | :---: | :---: |
| to_let_go_lists | user_id | ユーザー（FK） |
| 〃 | category_id | 手放すモノのカテゴリー（FK） |
| 〃 | item | 手放すモノの名前（string） | 
| 〃| reason_id | 手放す理由（FK） |

- 画像を添付できるようActiveStorageを導入
- 入力の手間を減らすため、`item`カラムはnull okに。もしnullだったら、表示上はカテゴリー名を入れる？
→ 現時点では`item`はユーザーにテキスト入力してもらう形だが、
　ゆくゆくは『カテゴリー選択時 or 画像添付時（画像認識API利用）』 →『 表示されるモノの候補から選択』とかにしたい

備考
---
- has_many関連付けのdependentオプション付与時に思ったこと：
CategoryモデルとReasonモデルは、今後シードデータを足したり引いたり試行錯誤していくつもりだから、物理削除ではなく論理削除にしたい。paranoiaが良さそう？
- 所要時間：1.3h

