### PR TITLE
手放したいアイテムから手放し済みアイテムにデータを引き継ぐ機能のスペックを作成 

### DIFF
--- a/spec/system/done_letting_go_items_spec.rb
+++ b/spec/system/done_letting_go_items_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe '手放し済みリスト' do
   end
 
   describe '新規登録' do
-    context '手放したいアイテムを新たに登録する場合' do
-      it '手放したものを新規登録できること' do
+    context '手放したアイテムをゼロから登録する場合' do
+      it '手放し済みアイテムを新規登録できること' do
         visit new_done_letting_go_item_path
         attach_file 'done_letting_go_item[image]', Rails.root.join('spec', 'fixtures', 'dummy.png')
-        find_by_id('done_letting_go_item_category_id').find("option[value='2']").select_option
+        select '生活雑貨', from: 'done_letting_go_item[category_id]'
         fill_in 'done_letting_go_item[name]', with: 'セーター'
-        find_by_id('done_letting_go_item_reason_id').find("option[value='2']").select_option
-        find_by_id('done_letting_go_item_letting_go_way_id').find("option[value='2']").select_option
+        select '使ってない', from: 'done_letting_go_item[reason_id]'
+        select 'ゴミに出す', from: 'done_letting_go_item[letting_go_way_id]'
         click_on '登録する'
         expect(page).to have_content '登録しました'
       end
@@ -27,7 +27,7 @@ RSpec.describe '手放し済みリスト' do
       it '手放し済みアイテム登録後に引き継ぎ元の手放したいアイテムは削除されること' do
         visit to_let_go_item_path(to_let_go_item)
         click_on '→ 手放す！'
-        find_by_id('done_letting_go_item_letting_go_way_id').find("option[value='2']").select_option
+        select 'ゴミに出す', from: 'done_letting_go_item[letting_go_way_id]'
         click_on '登録する'
         expect(page).to have_content '登録しました'
         expect{ ToLetGoItem.find(to_let_go_item.id) }.to raise_exception(ActiveRecord::RecordNotFound)

--- a/spec/system/done_letting_go_items_spec.rb
+++ b/spec/system/done_letting_go_items_spec.rb
@@ -8,15 +8,30 @@ RSpec.describe '手放し済みリスト' do
   end
 
   describe '新規登録' do
-    it '手放したものを新規登録できること' do
-      visit new_done_letting_go_item_path
-      attach_file 'done_letting_go_item[image]', Rails.root.join('spec', 'fixtures', 'dummy.png')
-      find_by_id('done_letting_go_item_category_id').find("option[value='2']").select_option
-      fill_in 'done_letting_go_item[name]', with: 'セーター'
-      find_by_id('done_letting_go_item_reason_id').find("option[value='2']").select_option
-      find_by_id('done_letting_go_item_letting_go_way_id').find("option[value='2']").select_option
-      click_on '登録する'
-      expect(page).to have_content '登録しました'
+    context '手放したいアイテムを新たに登録する場合' do
+      it '手放したものを新規登録できること' do
+        visit new_done_letting_go_item_path
+        attach_file 'done_letting_go_item[image]', Rails.root.join('spec', 'fixtures', 'dummy.png')
+        find_by_id('done_letting_go_item_category_id').find("option[value='2']").select_option
+        fill_in 'done_letting_go_item[name]', with: 'セーター'
+        find_by_id('done_letting_go_item_reason_id').find("option[value='2']").select_option
+        find_by_id('done_letting_go_item_letting_go_way_id').find("option[value='2']").select_option
+        click_on '登録する'
+        expect(page).to have_content '登録しました'
+      end
+    end
+
+    context '手放したいアイテムから手放すものを選ぶ場合' do
+      let!(:to_let_go_item) { create(:to_let_go_item, user: user) }
+
+      it '手放し済みアイテム登録後に引き継ぎ元の手放したいアイテムは削除されること' do
+        visit to_let_go_item_path(to_let_go_item)
+        click_on '→ 手放す！'
+        find_by_id('done_letting_go_item_letting_go_way_id').find("option[value='2']").select_option
+        click_on '登録する'
+        expect(page).to have_content '登録しました'
+        expect{ ToLetGoItem.find(to_let_go_item.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
     end
   end
 

--- a/spec/system/to_let_go_items_spec.rb
+++ b/spec/system/to_let_go_items_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe '手放したいものリスト' do
     it '手放したいものを新規登録できること' do
       visit new_to_let_go_item_path
       attach_file 'to_let_go_item[image]', Rails.root.join('spec', 'fixtures', 'dummy.png')
-      find_by_id('to_let_go_item_category_id').find("option[value='2']").select_option
+      select '生活雑貨', from: 'to_let_go_item[category_id]'
       fill_in 'to_let_go_item[name]', with: 'セーター'
-      find_by_id('to_let_go_item_reason_id').find("option[value='2']").select_option
+      select '使ってない', from: 'to_let_go_item[reason_id]'
       click_on '登録する'
       expect(page).to have_content '登録しました'
     end


### PR DESCRIPTION
概要
---

issue: #57

手放したいアイテムから「手放す！」ボタンを押して、手放し済みアイテムを登録する場合のスペックを作成しました。

備考
---
- 所要時間：.6h