### PR TITLE
手放したいものCRUDのリンク（「新規登録」「手放す」「編集」「削除」）表示を整える

### DIFF
--- a/app/views/done_letting_go_items/edit.html.erb
+++ b/app/views/done_letting_go_items/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, '手放済みアイテム編集' %>
+<% content_for :title, '手放し済み 編集' %>
 
 <div class="card card-style">
 <div class="content">

--- a/app/views/done_letting_go_items/edit.html.erb
+++ b/app/views/done_letting_go_items/edit.html.erb
@@ -1,6 +1,9 @@
+<% content_for :title do %>
+  <div class="header-title">手放済みアイテム編集</div>
+<% end %>
+
 <div class="card card-style">
 <div class="content">
-  <h3>手放し済みリストの編集</h3>
   <p>
     手放したモノの画像、カテゴリー、名前、手放す理由、手放す方法を入力してください。
   </p>

--- a/app/views/done_letting_go_items/edit.html.erb
+++ b/app/views/done_letting_go_items/edit.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title do %>
-  <div class="header-title">手放済みアイテム編集</div>
-<% end %>
+<% content_for :title, '手放済みアイテム編集' %>
 
 <div class="card card-style">
 <div class="content">

--- a/app/views/done_letting_go_items/index.html.erb
+++ b/app/views/done_letting_go_items/index.html.erb
@@ -1,8 +1,14 @@
 <% content_for :title do %>
   <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
-    <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-blue-light"></i></nobr>
+    <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-sunny-light"></i></nobr>
   <% end %>
 <% end %>
+
+<div class="text-center mb-3">
+  <span class="badge color-white bg-teal-dark me-3">カテゴリー<i class="fas fa-chevron-down font-8 ms-2"></i></span>
+  <span class="badge color-white bg-blue-light me-3">手放す理由<i class="fas fa-chevron-down font-8 ms-2"></i></span>
+  <span class="badge color-white bg-highlight-dark">手放す方法<i class="fas fa-chevron-down font-8 ms-2"></i></span>
+</div>
 
 <div class="card card-style">
   <div class="content">
@@ -11,20 +17,20 @@
       <%= link_to done_letting_go_item_path(done_letting_go_item), class: 'text-reset d-flex' do %>
         <div class="d-flex mb-3">
           <div class="ms-auto">
-            <%= image_tag done_letting_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
+            <%= image_tag done_letting_go_item.decorate.img(:thumb), size: '90x90', class: 'rounded-m bg-gray-light' %>
           </div>
-          <div class="w-100 ps-3">
+          <div class="w-100 px-2">
             <h5><%= done_letting_go_item.decorate.item_name %></h5>
-            <span>カテゴリー：<%= done_letting_go_item.category.name %></span><br>
-            <span>手放す理由：<%= done_letting_go_item.reason.name %></span><br>
-            <span>手放す方法：<%= done_letting_go_item.letting_go_way.name %></span>
+            <span class="badge color-white bg-teal-dark"><%= done_letting_go_item.category.name %></span>
+            <span class="badge color-white bg-blue-light"><%= done_letting_go_item.reason.name %></span><br>
+            <span class="badge color-white bg-highlight-dark"><%= done_letting_go_item.letting_go_way.name %></span><br>
           </div>
-          <div class="my-auto text-end">
-            <%= link_to edit_done_letting_go_item_path(done_letting_go_item), class: 'color-brown-dark edit-link' do %>
+          <div class="ms-auto text-end">
+            <%= link_to edit_done_letting_go_item_path(done_letting_go_item), class: 'text-reset edit-link' do %>
               <i class="fas fa-edit"></i>
-            <% end %>
+            <% end %><br>
             <%= link_to done_letting_go_item_path(done_letting_go_item),
-                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'text-reset delete-link' do %>
               <i class="far fa-times-circle mt-5"></i>
             <% end %>
           </div>

--- a/app/views/done_letting_go_items/index.html.erb
+++ b/app/views/done_letting_go_items/index.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title do %>
-    <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
-      <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
-    <% end %>
+  <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
+    <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-blue-light"></i></nobr>
+  <% end %>
 <% end %>
 
 <div class="card card-style">
   <div class="content">
     <%= '手放したものを登録してください。' if @done_letting_go_items.blank? %>
     <% @done_letting_go_items.each do |done_letting_go_item| %>
-      <%= link_to done_letting_go_item_path(done_letting_go_item), class: 'text-reset' do %>
+      <%= link_to done_letting_go_item_path(done_letting_go_item), class: 'text-reset d-flex' do %>
         <div class="d-flex mb-3">
           <div class="ms-auto">
             <%= image_tag done_letting_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
@@ -17,10 +17,16 @@
             <h5><%= done_letting_go_item.decorate.item_name %></h5>
             <span>カテゴリー：<%= done_letting_go_item.category.name %></span><br>
             <span>手放す理由：<%= done_letting_go_item.reason.name %></span><br>
-            <span>手放す方法：<%= done_letting_go_item.letting_go_way.name %></span><br>
-            <%= link_to '→ 編集する', edit_done_letting_go_item_path(done_letting_go_item), class: 'me-3' %>
-            <%= link_to '→ 削除する', done_letting_go_item_path(done_letting_go_item),
-                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+            <span>手放す方法：<%= done_letting_go_item.letting_go_way.name %></span>
+          </div>
+          <div class="my-auto text-end">
+            <%= link_to edit_done_letting_go_item_path(done_letting_go_item), class: 'color-brown-dark edit-link' do %>
+              <i class="fas fa-edit"></i>
+            <% end %>
+            <%= link_to done_letting_go_item_path(done_letting_go_item),
+                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+              <i class="far fa-times-circle mt-5"></i>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/done_letting_go_items/index.html.erb
+++ b/app/views/done_letting_go_items/index.html.erb
@@ -1,5 +1,11 @@
-<h3 class="mx-3">手放し済みリスト一覧</h3>
-<%= link_to '新規登録', new_done_letting_go_item_path, class: 'mx-3' %>
+<% content_for :title do %>
+  <div class="header-title">
+    <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
+      <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
     <%= '手放したものを登録してください。' if @done_letting_go_items.blank? %>

--- a/app/views/done_letting_go_items/index.html.erb
+++ b/app/views/done_letting_go_items/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %>
   <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
-    <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-sunny-light"></i></nobr>
+    <nobr>手放し済み リスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-sunny-light"></i></nobr>
   <% end %>
 <% end %>
 

--- a/app/views/done_letting_go_items/index.html.erb
+++ b/app/views/done_letting_go_items/index.html.erb
@@ -1,9 +1,7 @@
 <% content_for :title do %>
-  <div class="header-title">
     <%= link_to new_done_letting_go_item_path, class: 'text-reset' do %>
       <nobr>手放し済みリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
     <% end %>
-  </div>
 <% end %>
 
 <div class="card card-style">

--- a/app/views/done_letting_go_items/new.html.erb
+++ b/app/views/done_letting_go_items/new.html.erb
@@ -1,6 +1,9 @@
+<% content_for :title do %>
+  <div class="header-title">手放済みアイテム登録</div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
-    <h3>手放し済みリストの新規登録</h3>
     <p>
       手放したモノの画像、カテゴリー、名前、手放す理由、手放す方法を入力してください。
     </p>

--- a/app/views/done_letting_go_items/new.html.erb
+++ b/app/views/done_letting_go_items/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, '手放済みアイテム登録' %>
+<% content_for :title, '手放し済み 登録' %>
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/done_letting_go_items/new.html.erb
+++ b/app/views/done_letting_go_items/new.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title do %>
-  <div class="header-title">手放済みアイテム登録</div>
-<% end %>
+<% content_for :title, '手放済みアイテム登録' %>
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/done_letting_go_items/show.html.erb
+++ b/app/views/done_letting_go_items/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title do %>
-  <div class="header-title">手放済みアイテム詳細</div>
-<% end %>
+<% content_for :title, '手放済みアイテム詳細' %>
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/done_letting_go_items/show.html.erb
+++ b/app/views/done_letting_go_items/show.html.erb
@@ -4,18 +4,16 @@
   <div class="content">
     <div class="d-flex mb-3">
       <div class="ms-auto">
-        <%= image_tag @done_letting_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
+        <%= image_tag @done_letting_go_item.decorate.img(:thumb), size: '90x90', class: 'rounded-m bg-gray-light' %>
       </div>
       <div class="w-100 ps-3">
         <h5><%= @done_letting_go_item.decorate.item_name %></h5>
-        <span class="font-900">カテゴリー：<%= @done_letting_go_item.category.name %></span><br>
-        <span>カテゴリーの具体例：<%= @done_letting_go_item.category.description %></span><br>
-        <br>
-        <span class="font-900">手放す理由：<%= @done_letting_go_item.reason.name %></span><br>
-        <span>手放す理由の詳細：<%= @done_letting_go_item.reason.description %></span><br>
-        <br>
-        <span class="font-900">手放す方法：<%= @done_letting_go_item.letting_go_way.name %></span><br>
-        <span>手放す理由の詳細：<%= @done_letting_go_item.letting_go_way.description %></span><br>
+        <span class="badge color-white bg-teal-dark"><%= @done_letting_go_item.category.name %></span><br>
+        <p class="mb-3">具体例：<br><%= @done_letting_go_item.category.description %></p>
+        <span class="badge color-white bg-blue-light"><%= @done_letting_go_item.reason.name %></span><br>
+        <p class="mb-4">詳細：<br><%= @done_letting_go_item.reason.description %></p>
+        <span class="badge color-white bg-highlight-dark"><%= @done_letting_go_item.letting_go_way.name %></span><br>
+        <p class="mb-4">詳細：<br><%= @done_letting_go_item.letting_go_way.description %></p>
       </div>
       <div class="ms-1 text-end">
         <%= link_to edit_done_letting_go_item_path(@done_letting_go_item), class: 'color-brown-dark edit-link' do %>

--- a/app/views/done_letting_go_items/show.html.erb
+++ b/app/views/done_letting_go_items/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, '手放済みアイテム詳細' %>
+<% content_for :title, '手放し済み 詳細' %>
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/done_letting_go_items/show.html.erb
+++ b/app/views/done_letting_go_items/show.html.erb
@@ -16,10 +16,15 @@
         <br>
         <span class="font-900">手放す方法：<%= @done_letting_go_item.letting_go_way.name %></span><br>
         <span>手放す理由の詳細：<%= @done_letting_go_item.letting_go_way.description %></span><br>
-        <br>
-        <%= link_to '→ 編集する', edit_done_letting_go_item_path(@done_letting_go_item), class: 'me-3' %>
-        <%= link_to '→ 削除する', done_letting_go_item_path(@done_letting_go_item),
-                    data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+      </div>
+      <div class="ms-1 text-end">
+        <%= link_to edit_done_letting_go_item_path(@done_letting_go_item), class: 'color-brown-dark edit-link' do %>
+          <i class="fas fa-edit"></i>
+        <% end %>
+        <%= link_to done_letting_go_item_path(@done_letting_go_item),
+                    data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+          <i class="far fa-times-circle mt-4"></i>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/done_letting_go_items/show.html.erb
+++ b/app/views/done_letting_go_items/show.html.erb
@@ -1,4 +1,7 @@
-<h3 class="mx-3 mb-3">手放し済みリスト詳細</h3>
+<% content_for :title do %>
+  <div class="header-title">手放済みアイテム詳細</div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
     <div class="d-flex mb-3">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,5 @@
 <div class="header header-fixed header-logo-center">
-  <%#= link_to 'karoyaka', root_path, class: 'header-title' %>
-  <%= yield :title %>
+  <div class="header-title"><%= yield :title %></div>
   <%= link_to 'javascript:history.back()', class: 'header-icon header-icon-1' do %>
     <i class="fas fa-chevron-left"></i>
   <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,6 @@
 <div class="header header-fixed header-logo-center">
-  <%= link_to 'karoyaka', root_path, class: 'header-title' %>
+  <%#= link_to 'karoyaka', root_path, class: 'header-title' %>
+  <%= yield :title %>
   <%= link_to 'javascript:history.back()', class: 'header-icon header-icon-1' do %>
     <i class="fas fa-chevron-left"></i>
   <% end %>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -1,4 +1,5 @@
-<h3 class="mx-3 mb-4">捨て活したくなる名言集</h3>
+<% content_for :title, '捨て活モチベ⤴︎ 名言集' %>
+
 <% if user_signed_in? %>
   <div class="text-center mb-3">
     <%= active_link_to '全て表示', quotes_path, active: /.*quotes$/, class_active: 'active-nav',

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -1,4 +1,5 @@
-<h3 class="mx-3 mb-3">名言の詳細</h3>
+<% content_for :title, '名言の詳細' %>
+
 <div class="card card-style">
   <div class="content">
     <div class="d-flex">

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,6 +1,7 @@
+<% content_for :title, 'karoyakaについて' %>
+
 <div class="card card-style">
   <div class="content">
-    <h1>karoyakaについて</h1>
     <h2>使い方</h2>
     <h2>目的</h2>
   </div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,5 +1,6 @@
+<% content_for :title, 'プライバシーポリシー' %>
+
 <div class="card card-style">
   <div class="content">
-    <h1>プライバシーポリシー</h1>
   </div>
 </div>

--- a/app/views/static_pages/term.html.erb
+++ b/app/views/static_pages/term.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, '利用規約' %>
+
 <div class="card card-style">
   <div class="content">
     <h1>利用規約</h1>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,6 +1,7 @@
+<% content_for :title, 'トップページ' %>
+
 <div class="card card-style">
   <div class="content">
-    <h1>トップページ</h1>
     <p>１日に１つ、モノを手放そう</p>
 
     <h2>簡単２ステップ</h2>

--- a/app/views/to_let_go_items/edit.html.erb
+++ b/app/views/to_let_go_items/edit.html.erb
@@ -1,6 +1,9 @@
+<% content_for :title do %>
+  <div class="header-title">手放したいものを編集</div>
+<% end %>
+
 <div class="card card-style">
 <div class="content">
-  <h3>手放したいものリストの編集</h3>
   <p>
     手放したいモノの画像、カテゴリー、名前、手放す理由を入力してください。
   </p>

--- a/app/views/to_let_go_items/edit.html.erb
+++ b/app/views/to_let_go_items/edit.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title do %>
-  <div class="header-title">手放したいものを編集</div>
-<% end %>
+<% content_for :title, '手放したいものを編集' %>
 
 <div class="card card-style">
 <div class="content">

--- a/app/views/to_let_go_items/index.html.erb
+++ b/app/views/to_let_go_items/index.html.erb
@@ -1,5 +1,11 @@
-<h3 class="mx-3">手放したいものリスト一覧</h3>
-<%= link_to '新規登録', new_to_let_go_item_path, class: 'mx-3' %>
+<% content_for :title do %>
+  <div class="header-title">
+    <%= link_to new_to_let_go_item_path, class: 'text-reset' do %>
+      <nobr>手放したいものリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
+    <% end %>
+  </div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
     <%= '手放したいものを登録してください。' if @to_let_go_items.blank? %>

--- a/app/views/to_let_go_items/index.html.erb
+++ b/app/views/to_let_go_items/index.html.erb
@@ -13,14 +13,21 @@
           <div class="ms-auto">
             <%= image_tag to_let_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
           </div>
-          <div class="w-100 ps-3">
+          <div class="w-100 px-3">
             <h5><%= to_let_go_item.decorate.item_name %></h5>
             <span>カテゴリー：<%= to_let_go_item.category.name %></span><br>
             <span>手放す理由：<%= to_let_go_item.reason.name %></span><br>
-            <%= link_to '→ 手放す！', new_done_letting_go_item_path(item_id: to_let_go_item.id) %><br>
-            <%= link_to '→ 編集する', edit_to_let_go_item_path(to_let_go_item), class: 'me-3' %>
-            <%= link_to '→ 削除する', to_let_go_item_path(to_let_go_item),
-                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+            <%= link_to '手放す！', new_done_letting_go_item_path(item_id: to_let_go_item.id),
+                        class: 'btn btn-border btn-s btn-full font-700 border-green-dark color-green-dark bg-theme mt-1' %>
+          </div>
+          <div class="my-auto text-end">
+            <%= link_to edit_to_let_go_item_path(to_let_go_item), class: 'color-brown-dark edit-link' do %>
+              <i class="fas fa-edit"></i>
+            <% end %>
+            <%= link_to to_let_go_item_path(to_let_go_item),
+                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+              <i class="far fa-times-circle mt-5"></i>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/to_let_go_items/index.html.erb
+++ b/app/views/to_let_go_items/index.html.erb
@@ -1,9 +1,13 @@
 <% content_for :title do %>
-    <%= link_to new_to_let_go_item_path, class: 'text-reset' do %>
-      <nobr>手放したいものリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
-    <% end %>
+  <%= link_to new_to_let_go_item_path, class: 'text-reset' do %>
+    <nobr>手放したいものリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical color-sunny-light"></i></nobr>
+  <% end %>
 <% end %>
 
+<div class="text-center mb-3">
+  <span class="badge color-white bg-teal-dark me-3">カテゴリー <i class="fas fa-chevron-down font-8 ms-2"></i></span>
+  <span class="badge color-white bg-blue-light">手放す理由 <i class="fas fa-chevron-down font-8 ms-2"></i></span>
+</div>
 <div class="card card-style">
   <div class="content">
     <%= '手放したいものを登録してください。' if @to_let_go_items.blank? %>
@@ -11,21 +15,21 @@
       <%= link_to to_let_go_item_path(to_let_go_item), class: 'text-reset' do %>
         <div class="d-flex mb-3">
           <div class="ms-auto">
-            <%= image_tag to_let_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
+            <%= image_tag to_let_go_item.decorate.img(:thumb), size: '90x90', class: 'rounded-m bg-gray-light' %>
           </div>
-          <div class="w-100 px-3">
+          <div class="w-100 px-2">
             <h5><%= to_let_go_item.decorate.item_name %></h5>
-            <span>カテゴリー：<%= to_let_go_item.category.name %></span><br>
-            <span>手放す理由：<%= to_let_go_item.reason.name %></span><br>
+            <span class="badge color-white bg-teal-dark"><%= to_let_go_item.category.name %></span>
+            <span class="badge color-white bg-blue-light"><%= to_let_go_item.reason.name %></span><br>
             <%= link_to '手放す！', new_done_letting_go_item_path(item_id: to_let_go_item.id),
-                        class: 'btn btn-border btn-s btn-full font-700 border-green-dark color-green-dark bg-theme mt-1' %>
+                        class: 'btn btn-border btn-s btn-full font-700 border-green-dark color-green-dark bg-theme mt-2' %>
           </div>
           <div class="my-auto text-end">
-            <%= link_to edit_to_let_go_item_path(to_let_go_item), class: 'color-brown-dark edit-link' do %>
+            <%= link_to edit_to_let_go_item_path(to_let_go_item), class: 'text-reset edit-link' do %>
               <i class="fas fa-edit"></i>
             <% end %>
             <%= link_to to_let_go_item_path(to_let_go_item),
-                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+                        data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'text-reset delete-link' do %>
               <i class="far fa-times-circle mt-5"></i>
             <% end %>
           </div>

--- a/app/views/to_let_go_items/index.html.erb
+++ b/app/views/to_let_go_items/index.html.erb
@@ -1,9 +1,7 @@
 <% content_for :title do %>
-  <div class="header-title">
     <%= link_to new_to_let_go_item_path, class: 'text-reset' do %>
       <nobr>手放したいものリスト<i class="far fa-plus-square ms-2 font-18 btn-group-vertical"></i></nobr>
     <% end %>
-  </div>
 <% end %>
 
 <div class="card card-style">

--- a/app/views/to_let_go_items/new.html.erb
+++ b/app/views/to_let_go_items/new.html.erb
@@ -1,6 +1,5 @@
-<% content_for :title do %>
-  <div class="header-title">手放したいものを登録</div>
-<% end %>
+<% content_for :title, '手放したいものを登録' %>
+
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/to_let_go_items/new.html.erb
+++ b/app/views/to_let_go_items/new.html.erb
@@ -1,6 +1,9 @@
+<% content_for :title do %>
+  <div class="header-title">手放したいものを登録</div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
-    <h3>手放したいものリストの新規登録</h3>
     <p>
       手放したいモノの画像、カテゴリー、名前、手放す理由を入力してください。
     </p>

--- a/app/views/to_let_go_items/new.html.erb
+++ b/app/views/to_let_go_items/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, '手放したいものを登録' %>
 
-
 <div class="card card-style">
   <div class="content">
     <p>

--- a/app/views/to_let_go_items/show.html.erb
+++ b/app/views/to_let_go_items/show.html.erb
@@ -4,15 +4,14 @@
   <div class="content">
     <div class="d-flex mb-3">
       <div class="ms-auto">
-        <%= image_tag @to_let_go_item.decorate.img(:thumb), size: '100x100', class: 'rounded-m bg-gray-light' %>
+        <%= image_tag @to_let_go_item.decorate.img(:thumb), size: '90x90', class: 'rounded-m bg-gray-light' %>
       </div>
       <div class="w-100 ps-3">
         <h5><%= @to_let_go_item.decorate.item_name %></h5>
-        <span class="font-900">カテゴリー：<%= @to_let_go_item.category.name %></span><br>
-        <span>カテゴリーの具体例：<%= @to_let_go_item.category.description %></span><br>
-        <br>
-        <span class="font-900">手放す理由：<%= @to_let_go_item.reason.name %></span><br>
-        <span>手放す理由の詳細：<%= @to_let_go_item.reason.description %></span><br>
+        <span class="badge color-white bg-teal-dark"><%= @to_let_go_item.category.name %></span><br>
+        <p class="mb-3">具体例：<br><%= @to_let_go_item.category.description %></p>
+        <span class="badge color-white bg-blue-light"><%= @to_let_go_item.reason.name %></span><br>
+        <p class="mb-4">詳細：<br><%= @to_let_go_item.reason.description %></p>
         <%= link_to '手放す！', new_done_letting_go_item_path(item_id: @to_let_go_item.id),
                     class: 'btn btn-border btn-s btn-full font-700 border-green-dark color-green-dark bg-theme mt-1' %>
       </div>

--- a/app/views/to_let_go_items/show.html.erb
+++ b/app/views/to_let_go_items/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :title do %>
-  <div class="header-title">手放したいもの詳細</div>
-<% end %>
+<% content_for :title, '手放したいもの詳細' %>
 
 <div class="card card-style">
   <div class="content">

--- a/app/views/to_let_go_items/show.html.erb
+++ b/app/views/to_let_go_items/show.html.erb
@@ -1,4 +1,7 @@
-<h3 class="mx-3 mb-3">手放したいものリスト詳細</h3>
+<% content_for :title do %>
+  <div class="header-title">手放したいもの詳細</div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
     <div class="d-flex mb-3">

--- a/app/views/to_let_go_items/show.html.erb
+++ b/app/views/to_let_go_items/show.html.erb
@@ -13,11 +13,17 @@
         <br>
         <span class="font-900">手放す理由：<%= @to_let_go_item.reason.name %></span><br>
         <span>手放す理由の詳細：<%= @to_let_go_item.reason.description %></span><br>
-        <br>
-        <%= link_to '→ 手放す！', new_done_letting_go_item_path(item_id: @to_let_go_item.id) %><br>
-        <%= link_to '→ 編集する', edit_to_let_go_item_path(@to_let_go_item), class: 'me-3' %>
-        <%= link_to '→ 削除する', to_let_go_item_path(@to_let_go_item),
-                    data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+        <%= link_to '手放す！', new_done_letting_go_item_path(item_id: @to_let_go_item.id),
+                    class: 'btn btn-border btn-s btn-full font-700 border-green-dark color-green-dark bg-theme mt-1' %>
+      </div>
+      <div class="text-end">
+        <%= link_to edit_to_let_go_item_path(@to_let_go_item), class: 'color-brown-dark edit-link' do %>
+          <i class="fas fa-edit"></i>
+        <% end %>
+        <%= link_to to_let_go_item_path(@to_let_go_item),
+                    data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, class: 'color-red-light delete-link' do %>
+          <i class="far fa-times-circle mt-4"></i>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :title do %>
+  <div class="header-title">マイページ</div>
+<% end %>
+
 <div class="card card-style">
   <div class="content">
     <h1>Users#show</h1>

--- a/spec/system/done_letting_go_items_spec.rb
+++ b/spec/system/done_letting_go_items_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe '手放し済みリスト' do
     end
 
     context '手放したいアイテムから手放すものを選ぶ場合' do
-      let!(:to_let_go_item) { create(:to_let_go_item, user: user) }
+      let!(:to_let_go_item) { create(:to_let_go_item, user: user, category_id: 2) }
 
       it '手放し済みアイテム登録後に引き継ぎ元の手放したいアイテムは削除されること' do
         visit to_let_go_item_path(to_let_go_item)
-        click_on '→ 手放す！'
+        click_on '手放す！'
         select 'ゴミに出す', from: 'done_letting_go_item[letting_go_way_id]'
         click_on '登録する'
         expect(page).to have_content '登録しました'
@@ -40,7 +40,7 @@ RSpec.describe '手放し済みリスト' do
 
     it '編集ができること' do
       visit done_letting_go_item_path(done_letting_go_item)
-      click_on '編集する'
+      find('.edit-link').click
       fill_in 'done_letting_go_item[name]', with: 'スウェット'
       click_on '更新する'
       expect(page).to have_content '更新しました'
@@ -53,7 +53,7 @@ RSpec.describe '手放し済みリスト' do
 
     it '削除ができること' do
       visit done_letting_go_item_path(done_letting_go_item)
-      accept_confirm { click_on '削除' }
+      accept_confirm { find('.delete-link').click }
       expect(page).to have_content '削除しました'
       expect(page).not_to have_content done_letting_go_item.category.name
     end

--- a/spec/system/to_let_go_items_spec.rb
+++ b/spec/system/to_let_go_items_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe '手放したいものリスト' do
 
     it '編集ができること' do
       visit to_let_go_item_path(to_let_go_item)
-      click_on '編集する'
+      find('.edit-link').click
       fill_in 'to_let_go_item[name]', with: 'スウェット'
       click_on '更新する'
       expect(page).to have_content '更新しました'
@@ -37,7 +37,7 @@ RSpec.describe '手放したいものリスト' do
 
     it '削除ができること' do
       visit to_let_go_item_path(to_let_go_item)
-      accept_confirm { click_on '削除' }
+      accept_confirm { find('.delete-link').click }
       expect(page).to have_content '削除しました'
       expect(page).not_to have_content to_let_go_item.category.name
     end


### PR DESCRIPTION
概要
---

issue: #61 

UI の変更
----
手放したいアイテム一覧画面
<img width="372" alt="to_let_go_index" src="https://user-images.githubusercontent.com/105996822/213966184-d007a49d-f344-417c-8a2a-f65ab64da8a7.png">


手放したいアイテム詳細画面
<img width="374" alt="to_let_go_show" src="https://user-images.githubusercontent.com/105996822/213966195-3914b6a7-0fff-48db-b177-39ceb2d7a402.png">


手放し済みアイテム一覧画面
<img width="374" alt="done_index" src="https://user-images.githubusercontent.com/105996822/213966211-800825d1-0b83-4b3d-aab1-2855b651ec4c.png">

手放し済みアイテム詳細画面
<img width="375" alt="done_show" src="https://user-images.githubusercontent.com/105996822/213966449-d18e2f5b-7a5f-40ec-b6eb-8b893a4236ef.png">


実装の詳細
----

- ヘッダーメニューにページタイトルを表示
  - アイテム一覧画面では、新規登録リンクもヘッダーメニューに表示
- 「編集」「削除」「手放す」ボタンのスタイルを「ただの文字列」から「アイコン・ボタン」に変更
- 一覧画面、詳細画面にて、カテゴリー・手放す理由・手放す方法の文字列をバッジ表示に変更
  - 一覧画面トップにはソート機能を実装予定（今回はUI部分のみ作成） 

備考
---
- 所要時間：3h


