### PR TITLE
cardの最大幅を設定（レスポンシブ対応）

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -10,6 +10,7 @@ $card-under-bg-zindex:1;
 	max-height: 150000px;
     margin-bottom:$globalMargin;
 	background-position: center center !important;
+	max-width: 500px;
 }
 
 .cover-slider .card{margin-bottom:0px!important;}
@@ -22,6 +23,11 @@ $card-under-bg-zindex:1;
 	box-shadow: $globalShadow;
 	.card-body {
 		padding: 15px;
+	}
+}
+@media (min-width: 500px + $globalMargin*2) {
+	.card-style {
+		margin: 0px auto $globalMargin auto;
 	}
 }
 .card-style .card-overlay{

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -39,6 +39,6 @@
     <li class="me-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to '利用規約', term_path,
                                                                               class: 'color-dark-light' %><br></li>
     <li><i class="fas fa-chevron-right font-10"></i> <%= link_to 'プライバシーポリシー', privacy_path,
-                                                                              class: 'color-dark-light' %></li>
+                                                                 class: 'color-dark-light' %></li>
   </ul>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -31,14 +31,14 @@
   </div>
 </div>
 
-<div class="mx-5">
-  <h2 class="color-dark-light font-18">Links</h2>
-  <ul class="d-flex align-content-start flex-wrap list-unstyled">
-    <li class="mx-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to 'karoyakaについて', about_path,
+<div class="text-center d-flex flex-column align-content-center">
+  <h2 class="color-dark-light font-18 mb-2">Links</h2>
+  <ul class="d-flex align-content-center flex-wrap list-unstyled font-12 mx-auto">
+    <li class="me-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to 'karoyakaについて', about_path,
                                                                               class: 'color-dark-light' %></li>
-    <li class="mx-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to '利用規約', term_path,
+    <li class="me-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to '利用規約', term_path,
                                                                               class: 'color-dark-light' %><br></li>
-    <li class="mx-3"><i class="fas fa-chevron-right font-10"></i> <%= link_to 'プライバシーポリシー', privacy_path,
+    <li><i class="fas fa-chevron-right font-10"></i> <%= link_to 'プライバシーポリシー', privacy_path,
                                                                               class: 'color-dark-light' %></li>
   </ul>
 </div>


### PR DESCRIPTION
概要
---

issue: #96 

UI の変更
----

変更前
<img width="903" alt="スクリーンショット 2023-03-05 15 07 59" src="https://user-images.githubusercontent.com/105996822/222944571-b4a247c6-33bc-4ece-8394-9d00a7ca8183.png">


変更後
<img width="900" alt="スクリーンショット 2023-03-05 15 06 26" src="https://user-images.githubusercontent.com/105996822/222944547-1ad04981-47e4-42a9-bc7b-95f6c174a2d4.png">


実装の詳細
----

- 一定以上のデスプレイ幅ではcardの幅を固定
- トップページのLinksをレスポンシブ化

備考
---

- 所要時間：.5h